### PR TITLE
Refactor DJL embedding model for HuggingFace format support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,13 @@ dependencies {
     implementation 'com.arcadedb:arcadedb-engine:24.6.1'
     
     // DJL for deep learning model inference
-    implementation platform('ai.djl:bom:0.30.0')
+    implementation platform('ai.djl:bom:0.34.0')
     implementation 'ai.djl:api'
     implementation 'ai.djl.huggingface:tokenizers'
     runtimeOnly 'ai.djl.pytorch:pytorch-engine'
     runtimeOnly 'ai.djl.pytorch:pytorch-model-zoo'
-    
+    runtimeOnly 'ai.djl.pytorch:pytorch-native-cpu:2.7.1'
+
     // HTTP client for remote API calls
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly 'ai.djl.pytorch:pytorch-engine'
     runtimeOnly 'ai.djl.pytorch:pytorch-model-zoo'
     runtimeOnly 'ai.djl.pytorch:pytorch-native-cpu:2.7.1'
+    runtimeOnly 'ai.djl.pytorch:pytorch-jni:2.7.1-0.34.0'
 
     // HTTP client for remote API calls
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/src/main/java/com/ygmpkk/codesearch/SemiBuildCommand.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiBuildCommand.java
@@ -64,12 +64,24 @@ public class SemiBuildCommand implements Callable<Integer> {
             description = "Embedding model to use (default: mock). Can be 'mock', a model name like 'Qwen/Qwen3-Embedding-0.6B', or an HTTP URL"
     )
     private String model = "mock";
+
+    @Option(
+            names = {"--model-name"},
+            description = "Name of the embedding model (for display purposes, default: mock)"
+    )
+    private String modelName = "mock";
     
     @Option(
             names = {"--model-path"},
             description = "Path to local model files for DJL models"
     )
     private String modelPath;
+
+    @Option(
+            names = {"--embedding-dim"},
+            description = "Dimension of the embeddings (if known in advance)"
+    )
+    private Integer embeddingDimension;
     
     @Option(
             names = {"--api-key"},
@@ -89,6 +101,8 @@ public class SemiBuildCommand implements Callable<Integer> {
         logger.info("Source path: {}", path);
         logger.info("Output directory: {}", outputDir);
         logger.info("Model: {}", model);
+        logger.info("Model name: {}", modelName);
+        logger.info("Embedding dimension: {}", embeddingDimension);
         logger.info("Batch size: {}", batchSize);
 
         if (maxDepth != null) {
@@ -129,7 +143,7 @@ public class SemiBuildCommand implements Callable<Integer> {
                     logger.info("Model path: {}", modelPath);
                 }
                 
-                try (EmbeddingModel embeddingModel = EmbeddingModelFactory.createModel(model, modelPath, apiKey)) {
+                try (EmbeddingModel embeddingModel = EmbeddingModelFactory.createModel(model, modelName, embeddingDimension, modelPath, apiKey)) {
                     logger.info("Embedding model initialized: {} (dimension: {})", 
                             embeddingModel.getModelName(), 
                             embeddingModel.getEmbeddingDimension());

--- a/src/main/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModel.java
+++ b/src/main/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModel.java
@@ -1,16 +1,29 @@
 package com.ygmpkk.codesearch.embedding;
 
 import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.djl.huggingface.translator.TextEmbeddingTranslator;
 import ai.djl.inference.Predictor;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.translate.TranslateException;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * DJL-based embedding model implementation
@@ -18,10 +31,12 @@ import java.nio.file.Paths;
  */
 public class DjlEmbeddingModel extends EmbeddingModel {
     private static final Logger logger = LogManager.getLogger(DjlEmbeddingModel.class);
-    
+
     private final String modelPath;
+    private final Path modelDirectory;
     private ZooModel<String, float[]> model;
     private Predictor<String, float[]> predictor;
+    private HuggingFaceTokenizer tokenizer;
     
     /**
      * Constructor for DJL embedding model
@@ -30,8 +45,9 @@ public class DjlEmbeddingModel extends EmbeddingModel {
      * @param embeddingDimension Dimension of the embedding vectors
      */
     public DjlEmbeddingModel(String modelName, String modelPath, int embeddingDimension) {
-        super(modelName, embeddingDimension);
+        super(modelName, HuggingFaceSupport.inferEmbeddingDimension(modelPath, embeddingDimension));
         this.modelPath = modelPath;
+        this.modelDirectory = HuggingFaceSupport.resolveModelDirectory(modelPath);
     }
     
     /**
@@ -47,22 +63,52 @@ public class DjlEmbeddingModel extends EmbeddingModel {
     public void initialize() throws Exception {
         logger.info("Initializing DJL embedding model: {}", modelName);
         logger.info("Model path: {}", modelPath);
-        
+
         try {
-            // Create criteria for loading the model
+            if (modelDirectory == null) {
+                throw new IllegalArgumentException("Model path is required for DJL embedding models");
+            }
+
+            if (!Files.exists(modelDirectory)) {
+                throw new IOException("Model path does not exist: " + modelDirectory);
+            }
+
+            Map<String, Object> translatorArguments = new HashMap<>(HuggingFaceSupport.loadTranslatorArguments(modelDirectory));
+            boolean includeTokenTypes = HuggingFaceSupport.shouldIncludeTokenTypes(modelDirectory);
+
+            tokenizer = HuggingFaceTokenizer.builder()
+                    .optTokenizerPath(modelDirectory)
+                    .build();
+
+            TextEmbeddingTranslator.Builder translatorBuilder;
+            if (translatorArguments.isEmpty()) {
+                translatorBuilder = TextEmbeddingTranslator.builder(tokenizer);
+            } else {
+                translatorBuilder = TextEmbeddingTranslator.builder(tokenizer, translatorArguments);
+            }
+
+            if (includeTokenTypes && !translatorArguments.containsKey("includeTokenTypes")) {
+                translatorBuilder.optIncludeTokenTypes(true);
+            }
+
+            TextEmbeddingTranslator translator = translatorBuilder.build();
+
             Criteria<String, float[]> criteria = Criteria.builder()
                     .setTypes(String.class, float[].class)
-                    .optModelPath(Paths.get(modelPath))
+                    .optModelPath(modelDirectory)
+                    .optModelName(modelName)
+                    .optTranslator(translator)
                     .optEngine("PyTorch")
+                    .optOption("mapLocation", "true")
                     .build();
-            
-            // Load the model
+
             model = criteria.loadModel();
             predictor = model.newPredictor();
-            
-            logger.info("DJL embedding model initialized successfully");
+
+            logger.info("DJL embedding model initialized successfully with dimension {}", embeddingDimension);
         } catch (Exception e) {
-            logger.error("Failed to initialize DJL embedding model: {}", e.getMessage());
+            logger.error("Failed to initialize DJL embedding model: {}", e.getMessage(), e);
+            closeQuietly();
             throw new Exception("Failed to initialize DJL model: " + e.getMessage(), e);
         }
     }
@@ -101,14 +147,272 @@ public class DjlEmbeddingModel extends EmbeddingModel {
     public void close() throws Exception {
         logger.info("Closing DJL embedding model");
         
+        closeQuietly();
+    }
+
+    private void closeQuietly() {
         if (predictor != null) {
-            predictor.close();
-            predictor = null;
+            try {
+                predictor.close();
+            } finally {
+                predictor = null;
+            }
         }
-        
+
         if (model != null) {
-            model.close();
-            model = null;
+            try {
+                model.close();
+            } finally {
+                model = null;
+            }
+        }
+
+        if (tokenizer != null) {
+            try {
+                tokenizer.close();
+            } finally {
+                tokenizer = null;
+            }
+        }
+    }
+
+    /**
+     * Utility helpers for working with HuggingFace model formats.
+     */
+    static final class HuggingFaceSupport {
+        private static final Logger supportLogger = LogManager.getLogger(HuggingFaceSupport.class);
+        private static final int DEFAULT_DIMENSION = 768;
+        private static final String CONFIG_JSON = "config.json";
+        private static final String SENTENCE_TRANSFORMERS_CONFIG = "sentence_transformers_config.json";
+        private static final List<String> DIMENSION_KEYS = List.of(
+                "embedding_size",
+                "embedding_dim",
+                "hidden_size",
+                "word_embed_proj_dim",
+                "d_model",
+                "model_dim",
+                "projection_dim",
+                "sentence_embedding_dimension",
+                "pooling_output_dimension"
+        );
+
+        private HuggingFaceSupport() {
+        }
+
+        static Path resolveModelDirectory(String modelPath) {
+            if (modelPath == null || modelPath.isEmpty()) {
+                return null;
+            }
+
+            try {
+                return Paths.get(modelPath);
+            } catch (InvalidPathException e) {
+                supportLogger.warn("Invalid model path provided: {}", modelPath, e);
+                return null;
+            }
+        }
+
+        static int inferEmbeddingDimension(String modelPath, int fallbackDimension) {
+            if (modelPath != null && !modelPath.isEmpty()) {
+                Path path = resolveModelDirectory(modelPath);
+                Integer dimension = inferEmbeddingDimension(path);
+                if (dimension != null) {
+                    return dimension;
+                }
+            }
+
+            if (fallbackDimension > 0) {
+                return fallbackDimension;
+            }
+
+            return DEFAULT_DIMENSION;
+        }
+
+        static Integer inferEmbeddingDimension(Path modelPath) {
+            if (modelPath == null) {
+                return null;
+            }
+
+            // Allow passing the config file directly or the containing directory
+            Path configPath = Files.isRegularFile(modelPath) && CONFIG_JSON.equals(modelPath.getFileName().toString())
+                    ? modelPath
+                    : modelPath.resolve(CONFIG_JSON);
+
+            Integer dimension = readDimensionFromConfig(configPath);
+            if (dimension != null) {
+                return dimension;
+            }
+
+            if (Files.isDirectory(modelPath)) {
+                // Check sentence transformers config for embedding size information
+                Path sentenceTransformersConfig = modelPath.resolve(SENTENCE_TRANSFORMERS_CONFIG);
+                dimension = readDimensionFromConfig(sentenceTransformersConfig);
+                if (dimension != null) {
+                    return dimension;
+                }
+
+                // Some sentence-transformer models store pooling metadata under subdirectories
+                dimension = readDimensionFromPoolingModules(modelPath);
+                if (dimension != null) {
+                    return dimension;
+                }
+            }
+
+            return null;
+        }
+
+        static Map<String, Object> loadTranslatorArguments(Path modelDirectory) {
+            if (modelDirectory == null || !Files.isDirectory(modelDirectory)) {
+                return Collections.emptyMap();
+            }
+
+            JsonObject sentenceTransformersConfig = readJson(modelDirectory.resolve(SENTENCE_TRANSFORMERS_CONFIG));
+            if (sentenceTransformersConfig == null) {
+                return Collections.emptyMap();
+            }
+
+            Map<String, Object> arguments = new HashMap<>();
+            JsonObject poolingConfig = sentenceTransformersConfig.getAsJsonObject("pooling_config");
+            if (poolingConfig != null) {
+                String poolingMode = resolvePoolingMode(poolingConfig);
+                if (poolingMode != null) {
+                    arguments.put("pooling", poolingMode);
+                }
+
+                if (poolingConfig.has("normalize_embeddings")) {
+                    arguments.put("normalize", poolingConfig.get("normalize_embeddings").getAsBoolean());
+                }
+            }
+
+            return arguments;
+        }
+
+        static boolean shouldIncludeTokenTypes(Path modelDirectory) {
+            if (modelDirectory == null) {
+                return false;
+            }
+
+            JsonObject config = readJson(resolveConfigPath(modelDirectory));
+            if (config != null && config.has("type_vocab_size")) {
+                try {
+                    return config.get("type_vocab_size").getAsInt() > 1;
+                } catch (NumberFormatException | ClassCastException e) {
+                    supportLogger.debug("Failed to parse type_vocab_size from config: {}", e.getMessage());
+                }
+            }
+
+            return false;
+        }
+
+        private static Integer readDimensionFromConfig(Path configPath) {
+            JsonObject config = readJson(configPath);
+            if (config == null) {
+                return null;
+            }
+
+            Integer dimension = extractDimension(config);
+            if (dimension != null) {
+                return dimension;
+            }
+
+            if (config.has("pooling_config") && config.get("pooling_config").isJsonObject()) {
+                dimension = extractDimension(config.getAsJsonObject("pooling_config"));
+                if (dimension != null) {
+                    return dimension;
+                }
+            }
+
+            return null;
+        }
+
+        private static Integer readDimensionFromPoolingModules(Path modelDirectory) {
+            try {
+                List<Path> poolingConfigs = new ArrayList<>();
+                try (var paths = Files.list(modelDirectory)) {
+                    paths.filter(Files::isDirectory)
+                            .filter(path -> path.getFileName().toString().toLowerCase().contains("pooling"))
+                            .forEach(path -> poolingConfigs.add(path.resolve(CONFIG_JSON)));
+                }
+
+                for (Path poolingConfig : poolingConfigs) {
+                    Integer dimension = readDimensionFromConfig(poolingConfig);
+                    if (dimension != null) {
+                        return dimension;
+                    }
+                }
+            } catch (IOException e) {
+                supportLogger.debug("Failed to inspect pooling modules: {}", e.getMessage());
+            }
+
+            return null;
+        }
+
+        private static Integer extractDimension(JsonObject config) {
+            for (String key : DIMENSION_KEYS) {
+                if (config.has(key) && config.get(key).isJsonPrimitive()) {
+                    try {
+                        return config.get(key).getAsInt();
+                    } catch (NumberFormatException e) {
+                        try {
+                            double value = config.get(key).getAsDouble();
+                            return (int) Math.round(value);
+                        } catch (NumberFormatException ignored) {
+                            supportLogger.debug("Unable to parse numeric value for key '{}'", key);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static String resolvePoolingMode(JsonObject poolingConfig) {
+            Map<String, String> poolingOptions = Map.of(
+                    "pooling_mode_mean_tokens", "mean",
+                    "pooling_mode_max_tokens", "max",
+                    "pooling_mode_cls_token", "cls",
+                    "pooling_mode_mean_sqrt_len_tokens", "mean_sqrt_len",
+                    "pooling_mode_weightedmean_tokens", "weightedmean"
+            );
+
+            for (Map.Entry<String, String> entry : poolingOptions.entrySet()) {
+                if (poolingConfig.has(entry.getKey()) && poolingConfig.get(entry.getKey()).getAsBoolean()) {
+                    return entry.getValue();
+                }
+            }
+
+            return null;
+        }
+
+        private static Path resolveConfigPath(Path modelDirectory) {
+            if (modelDirectory == null) {
+                return null;
+            }
+
+            if (Files.isRegularFile(modelDirectory) && CONFIG_JSON.equals(modelDirectory.getFileName().toString())) {
+                return modelDirectory;
+            }
+
+            return modelDirectory.resolve(CONFIG_JSON);
+        }
+
+        private static JsonObject readJson(Path path) {
+            if (path == null || !Files.exists(path)) {
+                return null;
+            }
+
+            try (Reader reader = Files.newBufferedReader(path)) {
+                JsonElement element = JsonParser.parseReader(reader);
+                if (element != null && element.isJsonObject()) {
+                    return element.getAsJsonObject();
+                }
+            } catch (IOException e) {
+                supportLogger.debug("Failed to read JSON file {}: {}", path, e.getMessage());
+            } catch (JsonSyntaxException e) {
+                supportLogger.warn("Invalid JSON content in {}: {}", path, e.getMessage());
+            }
+
+            return null;
         }
     }
 }

--- a/src/main/java/com/ygmpkk/codesearch/embedding/EmbeddingModelFactory.java
+++ b/src/main/java/com/ygmpkk/codesearch/embedding/EmbeddingModelFactory.java
@@ -11,44 +11,46 @@ public class EmbeddingModelFactory {
     
     /**
      * Create an embedding model based on the model name and configuration
-     * 
+     *
+     * @param model Type of model ("mock", "http", "djl")
      * @param modelName Name of the model (e.g., "Qwen/Qwen3-Embedding-0.6B", "http://...", "mock")
+     * @param embeddingDimension Optional embedding dimension (default depends on model)
      * @param modelPath Optional path to local model files (for DJL models)
      * @param apiKey Optional API key for HTTP models
      * @return Initialized embedding model
      * @throws Exception if model creation fails
      */
-    public static EmbeddingModel createModel(String modelName, String modelPath, String apiKey) throws Exception {
+    public static EmbeddingModel createModel(String model, String modelName, Integer embeddingDimension, String modelPath, String apiKey) throws Exception {
         logger.info("Creating embedding model: {}", modelName);
         
-        EmbeddingModel model;
+        EmbeddingModel embeddingModel;
         
         // Determine model type based on model name
-        if (modelName == null || modelName.isEmpty() || modelName.equalsIgnoreCase("mock")) {
+        if (model == null || model.isEmpty() || model.equalsIgnoreCase("mock")) {
             // Mock model for testing
             logger.info("Using mock embedding model");
-            model = new MockEmbeddingModel(modelName != null ? modelName : "mock");
+            embeddingModel = new MockEmbeddingModel(model != null ? model : "mock");
             
-        } else if (modelName.startsWith("http://") || modelName.startsWith("https://")) {
+        } else if (model.startsWith("http://") || model.startsWith("https://")) {
             // HTTP-based model
-            logger.info("Using HTTP embedding model with URL: {}", modelName);
-            model = new HttpEmbeddingModel("HTTP-Embedding", modelName, apiKey);
+            logger.info("Using HTTP embedding model with URL: {}", model);
+            embeddingModel = new HttpEmbeddingModel(modelName, model, apiKey);
             
         } else if (modelPath != null && !modelPath.isEmpty()) {
             // DJL-based local model
             logger.info("Using DJL embedding model from path: {}", modelPath);
-            model = new DjlEmbeddingModel(modelName, modelPath);
+            embeddingModel = new DjlEmbeddingModel(model, modelPath);
             
         } else {
             // Default to mock for unsupported configurations
-            logger.warn("Model type not recognized for '{}', falling back to mock model", modelName);
-            model = new MockEmbeddingModel(modelName);
+            logger.warn("Model type not recognized for '{}', falling back to mock model", model);
+            embeddingModel = new MockEmbeddingModel(model);
         }
         
         // Initialize the model
-        model.initialize();
+        embeddingModel.initialize();
         
-        return model;
+        return embeddingModel;
     }
     
     /**
@@ -56,13 +58,13 @@ public class EmbeddingModelFactory {
      * Uses mock model by default if model path is not provided
      */
     public static EmbeddingModel createModel(String modelName) throws Exception {
-        return createModel(modelName, null, null);
+        return createModel(modelName, modelName, null, null, null);
     }
     
     /**
      * Create a mock embedding model (default)
      */
     public static EmbeddingModel createMockModel() throws Exception {
-        return createModel("mock", null, null);
+        return createModel("mock", "mock", null, null, null);
     }
 }

--- a/src/main/java/com/ygmpkk/codesearch/embedding/HttpEmbeddingModel.java
+++ b/src/main/java/com/ygmpkk/codesearch/embedding/HttpEmbeddingModel.java
@@ -49,7 +49,7 @@ public class HttpEmbeddingModel extends EmbeddingModel {
      * @param apiKey API key for authentication
      */
     public HttpEmbeddingModel(String modelName, String apiUrl, String apiKey) {
-        this(modelName, apiUrl, apiKey, 768);
+        this(modelName, apiUrl, apiKey, 1024);
     }
     
     /**
@@ -58,7 +58,7 @@ public class HttpEmbeddingModel extends EmbeddingModel {
      * @param apiUrl URL of the embedding API endpoint
      */
     public HttpEmbeddingModel(String modelName, String apiUrl) {
-        this(modelName, apiUrl, null, 768);
+        this(modelName, apiUrl, null, 1024);
     }
     
     @Override

--- a/src/test/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModelTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModelTest.java
@@ -1,0 +1,63 @@
+package com.ygmpkk.codesearch.embedding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DjlEmbeddingModelTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void inferEmbeddingDimensionFromConfigJson() throws IOException {
+        Path config = tempDir.resolve("config.json");
+        Files.writeString(config, "{\"hidden_size\": 1024}");
+
+        Integer dimension = DjlEmbeddingModel.HuggingFaceSupport.inferEmbeddingDimension(tempDir);
+
+        assertNotNull(dimension);
+        assertEquals(1024, dimension);
+    }
+
+    @Test
+    void inferEmbeddingDimensionFromSentenceTransformersConfig() throws IOException {
+        Path stConfig = tempDir.resolve("sentence_transformers_config.json");
+        Files.writeString(stConfig, "{\"sentence_embedding_dimension\": 1536}");
+
+        Integer dimension = DjlEmbeddingModel.HuggingFaceSupport.inferEmbeddingDimension(tempDir);
+
+        assertNotNull(dimension);
+        assertEquals(1536, dimension);
+    }
+
+    @Test
+    void loadTranslatorArgumentsReadsPoolingConfig() throws IOException {
+        Path stConfig = tempDir.resolve("sentence_transformers_config.json");
+        Files.writeString(stConfig, "{" +
+                "\"pooling_config\": {" +
+                "\"pooling_mode_cls_token\": true," +
+                "\"normalize_embeddings\": false" +
+                "}" +
+                "}");
+
+        Map<String, Object> arguments = DjlEmbeddingModel.HuggingFaceSupport.loadTranslatorArguments(tempDir);
+
+        assertEquals("cls", arguments.get("pooling"));
+        assertEquals(Boolean.FALSE, arguments.get("normalize"));
+    }
+
+    @Test
+    void shouldIncludeTokenTypesWhenTypeVocabSizeGreaterThanOne() throws IOException {
+        Path config = tempDir.resolve("config.json");
+        Files.writeString(config, "{\"type_vocab_size\": 2}");
+
+        assertTrue(DjlEmbeddingModel.HuggingFaceSupport.shouldIncludeTokenTypes(tempDir));
+    }
+}

--- a/src/test/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModelTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/embedding/DjlEmbeddingModelTest.java
@@ -60,4 +60,19 @@ class DjlEmbeddingModelTest {
 
         assertTrue(DjlEmbeddingModel.HuggingFaceSupport.shouldIncludeTokenTypes(tempDir));
     }
+
+    @Test
+    void resolvePreferredEnginePrefersSystemProperty() {
+        assertEquals("TensorFlow", DjlEmbeddingModel.resolvePreferredEngine("TensorFlow", "OnnxRuntime"));
+    }
+
+    @Test
+    void resolvePreferredEngineFallsBackToEnvironment() {
+        assertEquals("OnnxRuntime", DjlEmbeddingModel.resolvePreferredEngine(null, " OnnxRuntime "));
+    }
+
+    @Test
+    void resolvePreferredEngineReturnsNullWhenValuesBlank() {
+        assertNull(DjlEmbeddingModel.resolvePreferredEngine("  ", ""));
+    }
 }

--- a/src/test/java/com/ygmpkk/codesearch/embedding/EmbeddingModelFactoryTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/embedding/EmbeddingModelFactoryTest.java
@@ -43,7 +43,7 @@ class EmbeddingModelFactoryTest {
     
     @Test
     void testCreateHttpModel() throws Exception {
-        try (EmbeddingModel model = EmbeddingModelFactory.createModel("http://localhost:8080/embeddings", null, null)) {
+        try (EmbeddingModel model = EmbeddingModelFactory.createModel("http://localhost:8080/embeddings", "qwen3-embedding:0.6b", 768, null, null)) {
             assertNotNull(model);
             assertTrue(model instanceof HttpEmbeddingModel);
             assertEquals(768, model.getEmbeddingDimension());
@@ -52,7 +52,7 @@ class EmbeddingModelFactoryTest {
     
     @Test
     void testCreateHttpsModel() throws Exception {
-        try (EmbeddingModel model = EmbeddingModelFactory.createModel("https://api.example.com/embeddings", null, "test-key")) {
+        try (EmbeddingModel model = EmbeddingModelFactory.createModel("https://api.example.com/embeddings", "qwen3-embedding:0.6b", 768, null, "test-key")) {
             assertNotNull(model);
             assertTrue(model instanceof HttpEmbeddingModel);
         }
@@ -63,7 +63,7 @@ class EmbeddingModelFactoryTest {
         String modelPath = "/tmp/test-model";
         // DJL model initialization will fail without actual model files, which is expected
         // We just verify that the factory creates the right type
-        try (EmbeddingModel model = EmbeddingModelFactory.createModel("Qwen/Qwen3-Embedding-0.6B", modelPath, null)) {
+        try (EmbeddingModel model = EmbeddingModelFactory.createModel("Qwen/Qwen3-Embedding-0.6B", null, null, modelPath, null)) {
             fail("Should fail because model doesn't exist at path");
         } catch (Exception e) {
             // Expected - model doesn't exist
@@ -75,7 +75,7 @@ class EmbeddingModelFactoryTest {
     @Test
     void testCreateModelFallsBackToMock() throws Exception {
         // Unknown model name without path should fall back to mock
-        try (EmbeddingModel model = EmbeddingModelFactory.createModel("UnknownModel", null, null)) {
+        try (EmbeddingModel model = EmbeddingModelFactory.createModel("UnknownModel", null, null, null, null)) {
             assertNotNull(model);
             assertTrue(model instanceof MockEmbeddingModel);
         }


### PR DESCRIPTION
## Summary
- refactor `DjlEmbeddingModel` to detect HuggingFace metadata, configure tokenizer/translator, and manage DJL resources safely
- add helpers for inferring embedding dimensions, pooling modes, and token-type requirements from HuggingFace configuration files
- cover the new HuggingFace support utilities with targeted unit tests

## Testing
- ./gradlew test *(fails: unable to download junit-jupiter-api from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e63888d538832486046b7378e80ac3