### PR TITLE
feat: add config-driven semi search commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,23 @@ java -jar build/libs/code-semi-graph-1.0.0.jar semi build
 The build command will:
 - Scan your codebase for code files
 - Generate embeddings for each file using the specified embedding model
-- Store embeddings in an ArcadeDB database at `./.code-index/arcadedb-vector`
+- Store embeddings in an ArcadeDB database at `~/.code-semi-graph/index/arcadedb-vector` by default
 
 Available options:
-- `-p, --path <path>`: Path to build index from (default: current directory)
-- `-o, --output <path>`: Output directory for the index (default: ./.code-index)
+- `-p, --path <path>`: Path to build the index from (default: current directory)
+- `-o, --output <path>`: Output directory for the index (defaults to the configured index directory)
 - `-d, --depth <number>`: Maximum directory depth to traverse
 - `-e, --extensions <ext1,ext2>`: File extensions to index (comma-separated)
-- `-m, --model <model>`: Embedding model to use (default: mock). Can be:
+- `-m, --model <model>`: Embedding model to use. Can be:
   - `mock`: Mock embeddings for testing (default)
   - `Qwen/Qwen3-Embedding-0.6B` or other model names: Use with `--model-path`
   - `http://...` or `https://...`: Remote API endpoint URL
+- `--model-name <name>`: Display name for the embedding model
 - `--model-path <path>`: Path to local model files for DJL models
+- `--embedding-dim <number>`: Embedding dimension override
 - `--api-key <key>`: API key for HTTP-based embedding models
-- `--batch-size <size>`: Batch size for processing files (default: 32)
+- `--batch-size <size>`: Batch size for processing files
+- `--home <dir>`: Override the configuration home directory (default: `~/.code-semi-graph`)
 - `-h, --help`: Display help for the build command
 
 #### Embedding Model Strategies
@@ -115,6 +118,28 @@ Example:
 java -jar build/libs/code-semi-graph-1.0.0.jar semi build --path ./src --extensions java,kt --batch-size 16
 ```
 
+#### Configuration File
+
+The CLI reads defaults from `config.yaml`, located in the home directory `~/.code-semi-graph/` by default. The file is created
+automatically the first time you run a command and can be customised to change the default embedding model, index location and
+search preferences.
+
+```yaml
+embedding:
+  model: mock
+  modelName: mock
+  embeddingDimension: 1536
+  modelPath: ./models/qwen
+  apiKey: your-api-key
+  batchSize: 32
+index:
+  directory: ./index
+search:
+  topK: 5
+```
+
+Use the `--home <dir>` option on any semi command to load configuration from an alternative directory.
+
 #### Searching Code
 
 Perform a semi-structured code search:
@@ -124,14 +149,15 @@ java -jar build/libs/code-semi-graph-1.0.0.jar semi "search query"
 ```
 
 Available options:
-- `-p, --path <path>`: Path to search in (default: current directory)
-- `-d, --depth <number>`: Maximum search depth
-- `-e, --extensions <ext1,ext2>`: File extensions to search (comma-separated)
+- `-i, --index-dir <path>`: Directory that contains the embedding index (defaults to the configured index directory)
+- `-l, --limit <number>`: Maximum number of results to display (defaults to configuration)
+- Embedding overrides: `-m/--model`, `--model-name`, `--model-path`, `--embedding-dim`, `--api-key`
+- `--home <dir>`: Override the configuration home directory
 - `-h, --help`: Display help for the semi command
 
 Example:
 ```bash
-java -jar build/libs/code-semi-graph-1.0.0.jar semi "function name" --path /src --depth 3 --extensions java,kt
+java -jar build/libs/code-semi-graph-1.0.0.jar semi "function name" --index-dir ~/.code-semi-graph/index --limit 5
 ```
 
 ### Graph Code Search
@@ -185,7 +211,7 @@ Run the test suite:
 The application uses ArcadeDB, a multi-model database with native support for both vector embeddings and graph operations.
 
 ### ArcadeDB
-- **Vector Database Location**: `./.code-index/arcadedb-vector`
+- **Vector Database Location**: `~/.code-semi-graph/index/arcadedb-vector`
 - **Graph Database Location**: `./.code-index/arcadedb-graph`
 - **Benefits**: Native graph support, efficient vector similarity search, multi-model (document, graph, vector)
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.google.code.gson:gson:2.10.1'
 
+    // YAML configuration support
+    implementation 'org.yaml:snakeyaml:2.2'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
 }

--- a/src/main/java/com/ygmpkk/codesearch/EmbeddingOptions.java
+++ b/src/main/java/com/ygmpkk/codesearch/EmbeddingOptions.java
@@ -1,0 +1,84 @@
+package com.ygmpkk.codesearch;
+
+import picocli.CommandLine.Option;
+
+import java.nio.file.Path;
+
+/**
+ * Shared embedding options between build and search commands.
+ */
+public class EmbeddingOptions {
+    @Option(
+            names = {"-m", "--model"},
+            description = "Embedding model identifier. Supports 'mock', HTTP endpoints, or model names",
+            paramLabel = "MODEL"
+    )
+    private String model;
+
+    @Option(
+            names = {"--model-name"},
+            description = "Display name for the embedding model",
+            paramLabel = "NAME"
+    )
+    private String modelName;
+
+    @Option(
+            names = {"--model-path"},
+            description = "Path to local model files for DJL-based models",
+            paramLabel = "PATH"
+    )
+    private Path modelPath;
+
+    @Option(
+            names = {"--embedding-dim"},
+            description = "Dimension of the embeddings",
+            paramLabel = "DIMENSION"
+    )
+    private Integer embeddingDimension;
+
+    @Option(
+            names = {"--api-key"},
+            description = "API key for HTTP embedding providers",
+            paramLabel = "KEY"
+    )
+    private String apiKey;
+
+    @Option(
+            names = {"--batch-size"},
+            description = "Batch size for processing items",
+            paramLabel = "SIZE"
+    )
+    private Integer batchSize;
+
+    public String getModel() {
+        return normalize(model);
+    }
+
+    public String getModelName() {
+        return normalize(modelName);
+    }
+
+    public Path getModelPath() {
+        return modelPath;
+    }
+
+    public Integer getEmbeddingDimension() {
+        return embeddingDimension;
+    }
+
+    public String getApiKey() {
+        return normalize(apiKey);
+    }
+
+    public Integer getBatchSize() {
+        return batchSize;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/com/ygmpkk/codesearch/SemiBuildCommand.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiBuildCommand.java
@@ -1,9 +1,10 @@
 package com.ygmpkk.codesearch;
 
+import com.ygmpkk.codesearch.config.AppConfig;
+import com.ygmpkk.codesearch.config.ConfigLoader;
 import com.ygmpkk.codesearch.db.ArcadeDBVectorDatabase;
 import com.ygmpkk.codesearch.db.VectorDatabase;
 import com.ygmpkk.codesearch.embedding.EmbeddingModel;
-import com.ygmpkk.codesearch.embedding.EmbeddingModelFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,17 +35,22 @@ public class SemiBuildCommand implements Callable<Integer> {
     @Mixin
     LoggingMixin loggingMixin;
 
+    @Mixin
+    EmbeddingOptions embeddingOptions;
+
     @Option(
             names = {"-p", "--path"},
-            description = "Path to build index from (default: current directory)"
+            description = "Path to build index from",
+            paramLabel = "PATH"
     )
-    private String path = ".";
+    private Path sourcePath;
 
     @Option(
             names = {"-o", "--output"},
-            description = "Output directory for the index (default: ./.code-index)"
+            description = "Output directory for the index",
+            paramLabel = "DIR"
     )
-    private String outputDir = "./.code-index";
+    private Path outputDir;
 
     @Option(
             names = {"-e", "--extensions"},
@@ -60,75 +66,51 @@ public class SemiBuildCommand implements Callable<Integer> {
     private Integer maxDepth;
 
     @Option(
-            names = {"-m", "--model"},
-            description = "Embedding model to use (default: mock). Can be 'mock', a model name like 'Qwen/Qwen3-Embedding-0.6B', or an HTTP URL"
+            names = {"--home"},
+            description = "Home directory for configuration (default: userHome/.code-semi-graph)",
+            paramLabel = "DIR"
     )
-    private String model = "mock";
-
-    @Option(
-            names = {"--model-name"},
-            description = "Name of the embedding model (for display purposes, default: mock)"
-    )
-    private String modelName = "mock";
-    
-    @Option(
-            names = {"--model-path"},
-            description = "Path to local model files for DJL models"
-    )
-    private String modelPath;
-
-    @Option(
-            names = {"--embedding-dim"},
-            description = "Dimension of the embeddings (if known in advance)"
-    )
-    private Integer embeddingDimension;
-    
-    @Option(
-            names = {"--api-key"},
-            description = "API key for HTTP-based embedding models"
-    )
-    private String apiKey;
-
-    @Option(
-            names = {"--batch-size"},
-            description = "Batch size for processing files (default: 32)"
-    )
-    private int batchSize = 32;
+    private Path homeDirectory = SemiCommandSupport.defaultHome();
 
     @Override
     public Integer call() {
-        logger.info("Building embedding index...");
-        logger.info("Source path: {}", path);
-        logger.info("Output directory: {}", outputDir);
-        logger.info("Model: {}", model);
-        logger.info("Model name: {}", modelName);
-        logger.info("Embedding dimension: {}", embeddingDimension);
-        logger.info("Batch size: {}", batchSize);
-
-        if (maxDepth != null) {
-            logger.info("Max depth: {}", maxDepth);
-        }
-
-        if (extensions != null && extensions.length > 0) {
-            logger.info("Extensions: {}", String.join(", ", extensions));
-        }
-
         try {
-            // Create output directory if it doesn't exist
-            Path outputPath = Paths.get(outputDir);
-            Files.createDirectories(outputPath);
+            Path resolvedHome = SemiCommandSupport.resolveHomeDirectory(homeDirectory);
+            AppConfig appConfig = SemiCommandSupport.loadConfig(resolvedHome);
+            SemiCommandSupport.EmbeddingParameters embeddingParameters =
+                    SemiCommandSupport.resolveEmbeddingParameters(appConfig, embeddingOptions);
 
-            // Initialize vector database
-            String dbPath = outputPath.resolve("arcadedb-vector").toString();
-            logger.info("");
-            logger.info("Initializing vector database: {}", dbPath);
-            
-            try (VectorDatabase vectorDb = new ArcadeDBVectorDatabase(dbPath)) {
+            Path resolvedSource = (sourcePath != null ? sourcePath : Paths.get(".")).toAbsolutePath().normalize();
+            Path indexDirectory = SemiCommandSupport.resolveIndexDirectory(appConfig, outputDir);
+            Path vectorDbPath = SemiCommandSupport.resolveVectorDatabasePath(indexDirectory);
+
+            logger.info("Building embedding index...");
+            logger.info("Home directory: {}", resolvedHome);
+            logger.info("Configuration file: {}", ConfigLoader.resolveConfigPath(resolvedHome));
+            logger.info("Source path: {}", resolvedSource);
+            logger.info("Index directory: {}", indexDirectory);
+            logger.info("Vector database path: {}", vectorDbPath);
+            logger.info("Model: {}", embeddingParameters.model());
+            logger.info("Model name: {}", embeddingParameters.modelName());
+            logger.info("Embedding dimension: {}", embeddingParameters.embeddingDimension());
+            if (embeddingParameters.modelPath() != null) {
+                logger.info("Model path: {}", embeddingParameters.modelPath());
+            }
+            logger.info("API key provided: {}", embeddingParameters.apiKey() != null);
+            logger.info("Batch size: {}", embeddingParameters.batchSize());
+            if (maxDepth != null) {
+                logger.info("Max depth: {}", maxDepth);
+            }
+            if (extensions != null && extensions.length > 0) {
+                logger.info("Extensions: {}", String.join(", ", extensions));
+            }
+
+            Files.createDirectories(vectorDbPath);
+
+            try (VectorDatabase vectorDb = new ArcadeDBVectorDatabase(vectorDbPath.toString())) {
                 vectorDb.initialize();
-                
-                // Collect files to index
-                List<Path> filesToIndex = collectFiles();
-                logger.info("");
+
+                List<Path> filesToIndex = collectFiles(resolvedSource);
                 logger.info("Found {} files to index", filesToIndex.size());
 
                 if (filesToIndex.isEmpty()) {
@@ -136,20 +118,12 @@ public class SemiBuildCommand implements Callable<Integer> {
                     return 0;
                 }
 
-                // Initialize embedding model using factory
-                logger.info("");
-                logger.info("Initializing embedding model: {}", model);
-                if (modelPath != null) {
-                    logger.info("Model path: {}", modelPath);
-                }
-                
-                try (EmbeddingModel embeddingModel = EmbeddingModelFactory.createModel(model, modelName, embeddingDimension, modelPath, apiKey)) {
-                    logger.info("Embedding model initialized: {} (dimension: {})", 
-                            embeddingModel.getModelName(), 
+                try (EmbeddingModel embeddingModel = SemiCommandSupport.createEmbeddingModel(embeddingParameters)) {
+                    logger.info("Embedding model initialized: {} (dimension: {})",
+                            embeddingModel.getModelName(),
                             embeddingModel.getEmbeddingDimension());
 
-                    // Process files in batches
-                    logger.info("");
+                    int batchSize = embeddingParameters.batchSize();
                     logger.info("Processing files in batches of {}...", batchSize);
                     int totalBatches = (int) Math.ceil((double) filesToIndex.size() / batchSize);
 
@@ -162,30 +136,22 @@ public class SemiBuildCommand implements Callable<Integer> {
 
                         for (Path file : batch) {
                             try {
-                                // Read file content
                                 String content = Files.readString(file);
-                                
-                                // Generate embedding using the model
                                 float[] embedding = embeddingModel.generateEmbedding(content);
-                                
-                                // Store in database
                                 vectorDb.storeEmbedding(file.toString(), content, embedding);
-                                
-                                logger.debug("  - Indexed: {}", file);
+                                logger.debug("Indexed: {}", file);
                             } catch (Exception e) {
-                                logger.warn("  - Failed to index {}: {}", file, e.getMessage());
+                                logger.warn("Failed to index {}: {}", file, e.getMessage());
                             }
                         }
                     }
 
                     int embeddingCount = vectorDb.getEmbeddingCount();
-                    logger.info("");
                     logger.info("✓ Embedding index built successfully!");
-                    logger.info("Index location: {}", outputPath.toAbsolutePath());
+                    logger.info("Index location: {}", indexDirectory);
                     logger.info("Total embeddings stored: {}", embeddingCount);
                 }
             }
-
         } catch (Exception e) {
             logger.error("Error building index: {}", e.getMessage());
             logger.debug("Stack trace:", e);
@@ -195,12 +161,11 @@ public class SemiBuildCommand implements Callable<Integer> {
         return 0;
     }
 
-    private List<Path> collectFiles() throws IOException {
+    private List<Path> collectFiles(Path sourcePath) throws IOException {
         List<Path> files = new ArrayList<>();
-        Path sourcePath = Paths.get(path);
 
         if (!Files.exists(sourcePath)) {
-            logger.error("Error: Path does not exist: {}", path);
+            logger.error("Error: Path does not exist: {}", sourcePath);
             return files;
         }
 
@@ -211,7 +176,6 @@ public class SemiBuildCommand implements Callable<Integer> {
             return files;
         }
 
-        // Traverse directory with error handling
         int depth = (maxDepth != null) ? maxDepth : Integer.MAX_VALUE;
 
         try (Stream<Path> pathStream = Files.walk(sourcePath, depth)) {
@@ -220,14 +184,12 @@ public class SemiBuildCommand implements Callable<Integer> {
                         try {
                             return Files.isRegularFile(p);
                         } catch (Exception e) {
-                            // Skip files that can't be accessed
                             return false;
                         }
                     })
                     .filter(this::shouldIncludeFile)
                     .forEach(files::add);
         } catch (Exception e) {
-            // If walk fails completely, try to handle gracefully
             logger.warn("Warning: Error traversing directory: {}", e.getMessage());
         }
 
@@ -237,7 +199,6 @@ public class SemiBuildCommand implements Callable<Integer> {
     private boolean shouldIncludeFile(Path file) {
         String fileName = file.getFileName().toString();
 
-        // Skip hidden files and common non-source directories
         if (fileName.startsWith(".") ||
                 file.toString().contains("/.git/") ||
                 file.toString().contains("/node_modules/") ||
@@ -247,7 +208,6 @@ public class SemiBuildCommand implements Callable<Integer> {
             return false;
         }
 
-        // If extensions are specified, check if file matches
         if (extensions != null && extensions.length > 0) {
             for (String ext : extensions) {
                 if (fileName.endsWith("." + ext)) {
@@ -257,7 +217,6 @@ public class SemiBuildCommand implements Callable<Integer> {
             return false;
         }
 
-        // Default: include common code file extensions
         return fileName.endsWith(".java") ||
                 fileName.endsWith(".kt") ||
                 fileName.endsWith(".js") ||

--- a/src/main/java/com/ygmpkk/codesearch/SemiCommandSupport.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiCommandSupport.java
@@ -1,0 +1,101 @@
+package com.ygmpkk.codesearch;
+
+import com.ygmpkk.codesearch.config.AppConfig;
+import com.ygmpkk.codesearch.config.ConfigLoader;
+import com.ygmpkk.codesearch.embedding.EmbeddingModel;
+import com.ygmpkk.codesearch.embedding.EmbeddingModelFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Helper utilities shared between semi build and search commands.
+ */
+public final class SemiCommandSupport {
+    private static final Path DEFAULT_HOME = Paths.get(System.getProperty("user.home"), ".code-semi-graph");
+    private static final String VECTOR_DB_DIRECTORY = "arcadedb-vector";
+
+    private SemiCommandSupport() {
+    }
+
+    public static Path defaultHome() {
+        return DEFAULT_HOME;
+    }
+
+    public static Path resolveHomeDirectory(Path requestedHome) throws Exception {
+        Path home = (requestedHome != null ? requestedHome : DEFAULT_HOME).toAbsolutePath().normalize();
+        Files.createDirectories(home);
+        return home;
+    }
+
+    public static AppConfig loadConfig(Path homeDirectory) {
+        return ConfigLoader.load(homeDirectory);
+    }
+
+    public static EmbeddingParameters resolveEmbeddingParameters(AppConfig appConfig, EmbeddingOptions options) {
+        AppConfig.EmbeddingConfig config = appConfig.getEmbedding();
+
+        String model = firstNonBlank(options.getModel(), config.getModel());
+        String modelName = firstNonBlank(options.getModelName(), config.getModelName());
+        if (modelName == null || modelName.isBlank()) {
+            modelName = model;
+        }
+
+        Integer embeddingDimension = options.getEmbeddingDimension() != null
+                ? options.getEmbeddingDimension()
+                : config.getEmbeddingDimension();
+
+        Path modelPath = options.getModelPath() != null
+                ? options.getModelPath().toAbsolutePath().normalize()
+                : config.getModelPath();
+
+        String apiKey = firstNonBlank(options.getApiKey(), config.getApiKey());
+        int batchSize = options.getBatchSize() != null && options.getBatchSize() > 0
+                ? options.getBatchSize()
+                : config.getBatchSize();
+
+        return new EmbeddingParameters(model, modelName, embeddingDimension, modelPath, apiKey, batchSize);
+    }
+
+    public static EmbeddingModel createEmbeddingModel(EmbeddingParameters parameters) throws Exception {
+        return EmbeddingModelFactory.createModel(
+                parameters.model(),
+                parameters.modelName(),
+                parameters.embeddingDimension(),
+                parameters.modelPath() != null ? parameters.modelPath().toString() : null,
+                parameters.apiKey()
+        );
+    }
+
+    public static Path resolveIndexDirectory(AppConfig appConfig, Path override) throws Exception {
+        Path directory = override != null ? override : appConfig.getIndex().getDirectory();
+        Path normalized = directory.toAbsolutePath().normalize();
+        Files.createDirectories(normalized);
+        return normalized;
+    }
+
+    public static Path resolveVectorDatabasePath(Path indexDirectory) {
+        return indexDirectory.resolve(VECTOR_DB_DIRECTORY);
+    }
+
+    private static String firstNonBlank(String value, String fallback) {
+        if (value != null && !value.isBlank()) {
+            return value;
+        }
+        return fallback;
+    }
+
+    /**
+     * Aggregated embedding parameters resolved from configuration and CLI options.
+     */
+    public record EmbeddingParameters(
+            String model,
+            String modelName,
+            Integer embeddingDimension,
+            Path modelPath,
+            String apiKey,
+            int batchSize
+    ) {
+    }
+}

--- a/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
@@ -1,5 +1,10 @@
 package com.ygmpkk.codesearch;
 
+import com.ygmpkk.codesearch.config.AppConfig;
+import com.ygmpkk.codesearch.config.ConfigLoader;
+import com.ygmpkk.codesearch.db.ArcadeDBVectorDatabase;
+import com.ygmpkk.codesearch.db.VectorDatabase;
+import com.ygmpkk.codesearch.embedding.EmbeddingModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -8,6 +13,10 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -22,10 +31,13 @@ import java.util.concurrent.Callable;
     }
 )
 public class SemiSearchCommand implements Callable<Integer> {
-    private static Logger logger = LogManager.getLogger(SemiSearchCommand.class);
+    private static final Logger logger = LogManager.getLogger(SemiSearchCommand.class);
 
     @Mixin
     LoggingMixin loggingMixin;
+
+    @Mixin
+    EmbeddingOptions embeddingOptions;
 
     @Parameters(
         index = "0",
@@ -35,27 +47,28 @@ public class SemiSearchCommand implements Callable<Integer> {
     private String query;
 
     @Option(
-        names = {"-p", "--path"},
-        description = "Path to search in (default: current directory)"
+        names = {"-i", "--index-dir"},
+        description = "Directory containing the embedding index",
+        paramLabel = "DIR"
     )
-    private String path = ".";
+    private Path indexDirectory;
 
     @Option(
-        names = {"-d", "--depth"},
-        description = "Maximum search depth (default: unlimited)"
+        names = {"-l", "--limit"},
+        description = "Maximum number of results to return",
+        paramLabel = "N"
     )
-    private Integer maxDepth;
+    private Integer resultLimit;
 
     @Option(
-        names = {"-e", "--extensions"},
-        description = "File extensions to search (comma-separated)",
-        split = ","
+        names = {"--home"},
+        description = "Home directory for configuration (default: userHome/.code-semi-graph)",
+        paramLabel = "DIR"
     )
-    private String[] extensions;
+    private Path homeDirectory = SemiCommandSupport.defaultHome();
 
     @Override
     public Integer call() {
-        // If no query is provided, show help
         if (query == null || query.isEmpty()) {
             logger.info("Use 'semi --help' to see available commands and options");
             logger.info("Available subcommands:");
@@ -65,23 +78,77 @@ public class SemiSearchCommand implements Callable<Integer> {
             logger.info("  semi \"your query\" [options]");
             return 0;
         }
-        
-        logger.info("Performing semi code search...");
-        logger.info("Query: {}", query);
-        logger.info("Path: {}", path);
-        
-        if (maxDepth != null) {
-            logger.info("Max depth: {}", maxDepth);
+
+        try {
+            Path resolvedHome = SemiCommandSupport.resolveHomeDirectory(homeDirectory);
+            AppConfig appConfig = SemiCommandSupport.loadConfig(resolvedHome);
+            SemiCommandSupport.EmbeddingParameters embeddingParameters =
+                    SemiCommandSupport.resolveEmbeddingParameters(appConfig, embeddingOptions);
+
+            Path resolvedIndexDir = determineIndexDirectory(appConfig);
+            Path vectorDbPath = SemiCommandSupport.resolveVectorDatabasePath(resolvedIndexDir);
+
+            if (Files.notExists(vectorDbPath)) {
+                logger.error("Embedding index not found at {}", vectorDbPath);
+                System.err.printf("Embedding index not found at %s%n", vectorDbPath);
+                return 1;
+            }
+
+            int limit = (resultLimit != null && resultLimit > 0)
+                    ? resultLimit
+                    : appConfig.getSearch().getTopK();
+
+            logger.info("Performing semi code search...");
+            logger.info("Home directory: {}", resolvedHome);
+            logger.info("Configuration file: {}", ConfigLoader.resolveConfigPath(resolvedHome));
+            logger.info("Index directory: {}", resolvedIndexDir);
+            logger.info("Vector database path: {}", vectorDbPath);
+            logger.info("Model: {}", embeddingParameters.model());
+            logger.info("Model name: {}", embeddingParameters.modelName());
+            logger.info("Embedding dimension: {}", embeddingParameters.embeddingDimension());
+            if (embeddingParameters.modelPath() != null) {
+                logger.info("Model path: {}", embeddingParameters.modelPath());
+            }
+            logger.info("Result limit: {}", limit);
+
+            try (VectorDatabase vectorDb = new ArcadeDBVectorDatabase(vectorDbPath.toString());
+                 EmbeddingModel embeddingModel = SemiCommandSupport.createEmbeddingModel(embeddingParameters)) {
+
+                float[] queryEmbedding = embeddingModel.generateEmbedding(query);
+                List<VectorDatabase.SearchResult> results = vectorDb.searchSimilar(queryEmbedding, limit);
+
+                if (results.isEmpty()) {
+                    logger.info("No matching code found for query '{}'.", query);
+                    System.out.println("No matching code found.");
+                    return 0;
+                }
+
+                logger.info("Found {} matching results", results.size());
+                System.out.println();
+                System.out.printf("Top %d results for '%s':%n", results.size(), query);
+
+                int rank = 1;
+                for (VectorDatabase.SearchResult result : results) {
+                    System.out.printf(
+                            "%d. %s (similarity: %.4f)%n",
+                            rank++,
+                            result.getFilePath(),
+                            result.getSimilarity()
+                    );
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error performing search: {}", e.getMessage());
+            logger.debug("Stack trace:", e);
+            System.err.printf("Search failed: %s%n", e.getMessage());
+            return 1;
         }
-        
-        if (extensions != null && extensions.length > 0) {
-            logger.info("Extensions: {}", String.join(", ", extensions));
-        }
-        
-        // TODO: Implement actual semi search logic
-        logger.info("");
-        logger.info("Semi search completed (implementation pending)");
-        
+
         return 0;
+    }
+
+    private Path determineIndexDirectory(AppConfig appConfig) {
+        Path directory = indexDirectory != null ? indexDirectory : appConfig.getIndex().getDirectory();
+        return (directory != null ? directory : Paths.get(".")).toAbsolutePath().normalize();
     }
 }

--- a/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
@@ -54,6 +54,28 @@ public class SemiSearchCommand implements Callable<Integer> {
     private Path indexDirectory;
 
     @Option(
+        names = {"-p", "--path"},
+        description = "Legacy option: path to search (deprecated, kept for compatibility)",
+        paramLabel = "PATH"
+    )
+    private String path;
+
+    @Option(
+        names = {"-d", "--depth"},
+        description = "Legacy option: maximum search depth (deprecated)",
+        paramLabel = "DEPTH"
+    )
+    private Integer maxDepth;
+
+    @Option(
+        names = {"-e", "--extensions"},
+        description = "Legacy option: comma-separated file extensions (deprecated)",
+        paramLabel = "EXTENSIONS",
+        split = ","
+    )
+    private String[] extensions;
+
+    @Option(
         names = {"-l", "--limit"},
         description = "Maximum number of results to return",
         paramLabel = "N"
@@ -110,6 +132,16 @@ public class SemiSearchCommand implements Callable<Integer> {
                 logger.info("Model path: {}", embeddingParameters.modelPath());
             }
             logger.info("Result limit: {}", limit);
+
+            if (path != null && !path.isBlank()) {
+                logger.info("(legacy) Search path option provided: {}", path);
+            }
+            if (maxDepth != null) {
+                logger.info("(legacy) Max depth option provided: {}", maxDepth);
+            }
+            if (extensions != null && extensions.length > 0) {
+                logger.info("(legacy) Extensions filter provided: {}", String.join(", ", extensions));
+            }
 
             try (VectorDatabase vectorDb = new ArcadeDBVectorDatabase(vectorDbPath.toString());
                  EmbeddingModel embeddingModel = SemiCommandSupport.createEmbeddingModel(embeddingParameters)) {

--- a/src/main/java/com/ygmpkk/codesearch/config/AppConfig.java
+++ b/src/main/java/com/ygmpkk/codesearch/config/AppConfig.java
@@ -1,0 +1,308 @@
+package com.ygmpkk.codesearch.config;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Application configuration loaded from {@code config.yaml}.
+ */
+public final class AppConfig {
+    private final Path homeDirectory;
+    private final EmbeddingConfig embedding;
+    private final IndexConfig index;
+    private final SearchConfig search;
+
+    private AppConfig(Builder builder) {
+        this.homeDirectory = builder.homeDirectory;
+        this.embedding = builder.embedding;
+        this.index = builder.index;
+        this.search = builder.search;
+    }
+
+    /**
+     * Create a default configuration for the provided home directory.
+     */
+    public static AppConfig createDefault(Path homeDirectory) {
+        Objects.requireNonNull(homeDirectory, "homeDirectory");
+        return builder()
+                .withHomeDirectory(homeDirectory)
+                .withEmbedding(EmbeddingConfig.builder()
+                        .withModel("mock")
+                        .withModelName("mock")
+                        .withBatchSize(32)
+                        .build())
+                .withIndex(IndexConfig.builder()
+                        .withDirectory(homeDirectory.resolve("index"))
+                        .build())
+                .withSearch(SearchConfig.builder()
+                        .withTopK(5)
+                        .build())
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Path getHomeDirectory() {
+        return homeDirectory;
+    }
+
+    public EmbeddingConfig getEmbedding() {
+        return embedding;
+    }
+
+    public IndexConfig getIndex() {
+        return index;
+    }
+
+    public SearchConfig getSearch() {
+        return search;
+    }
+
+    /**
+     * Convert the configuration to a serializable map representation.
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> root = new LinkedHashMap<>();
+
+        Map<String, Object> embeddingMap = new LinkedHashMap<>();
+        embeddingMap.put("model", embedding.getModel());
+        embeddingMap.put("modelName", embedding.getModelName());
+        if (embedding.getEmbeddingDimension() != null) {
+            embeddingMap.put("embeddingDimension", embedding.getEmbeddingDimension());
+        }
+        if (embedding.getModelPath() != null) {
+            embeddingMap.put("modelPath", relativize(embedding.getModelPath()));
+        }
+        if (embedding.getApiKey() != null) {
+            embeddingMap.put("apiKey", embedding.getApiKey());
+        }
+        embeddingMap.put("batchSize", embedding.getBatchSize());
+        root.put("embedding", embeddingMap);
+
+        Map<String, Object> indexMap = new LinkedHashMap<>();
+        indexMap.put("directory", relativize(index.getDirectory()));
+        root.put("index", indexMap);
+
+        Map<String, Object> searchMap = new LinkedHashMap<>();
+        searchMap.put("topK", search.getTopK());
+        root.put("search", searchMap);
+
+        return root;
+    }
+
+    private String relativize(Path path) {
+        Path normalized = path.normalize();
+        if (normalized.startsWith(homeDirectory)) {
+            return homeDirectory.relativize(normalized).toString();
+        }
+        return normalized.toString();
+    }
+
+    public static final class Builder {
+        private Path homeDirectory;
+        private EmbeddingConfig embedding;
+        private IndexConfig index;
+        private SearchConfig search;
+
+        private Builder() {
+        }
+
+        public Builder withHomeDirectory(Path homeDirectory) {
+            this.homeDirectory = homeDirectory;
+            return this;
+        }
+
+        public Builder withEmbedding(EmbeddingConfig embedding) {
+            this.embedding = embedding;
+            return this;
+        }
+
+        public Builder withIndex(IndexConfig index) {
+            this.index = index;
+            return this;
+        }
+
+        public Builder withSearch(SearchConfig search) {
+            this.search = search;
+            return this;
+        }
+
+        public AppConfig build() {
+            Objects.requireNonNull(homeDirectory, "homeDirectory");
+            Objects.requireNonNull(embedding, "embedding");
+            Objects.requireNonNull(index, "index");
+            Objects.requireNonNull(search, "search");
+            return new AppConfig(this);
+        }
+    }
+
+    /**
+     * Embedding configuration section.
+     */
+    public static final class EmbeddingConfig {
+        private final String model;
+        private final String modelName;
+        private final Integer embeddingDimension;
+        private final Path modelPath;
+        private final String apiKey;
+        private final int batchSize;
+
+        private EmbeddingConfig(EmbeddingBuilder builder) {
+            this.model = builder.model;
+            this.modelName = builder.modelName;
+            this.embeddingDimension = builder.embeddingDimension;
+            this.modelPath = builder.modelPath;
+            this.apiKey = builder.apiKey;
+            this.batchSize = builder.batchSize != null ? Math.max(1, builder.batchSize) : 32;
+        }
+
+        public static EmbeddingBuilder builder() {
+            return new EmbeddingBuilder();
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public String getModelName() {
+            return modelName;
+        }
+
+        public Integer getEmbeddingDimension() {
+            return embeddingDimension;
+        }
+
+        public Path getModelPath() {
+            return modelPath;
+        }
+
+        public String getApiKey() {
+            return apiKey;
+        }
+
+        public int getBatchSize() {
+            return batchSize;
+        }
+
+        public static final class EmbeddingBuilder {
+            private String model;
+            private String modelName;
+            private Integer embeddingDimension;
+            private Path modelPath;
+            private String apiKey;
+            private Integer batchSize;
+
+            private EmbeddingBuilder() {
+            }
+
+            public EmbeddingBuilder withModel(String model) {
+                this.model = model;
+                return this;
+            }
+
+            public EmbeddingBuilder withModelName(String modelName) {
+                this.modelName = modelName;
+                return this;
+            }
+
+            public EmbeddingBuilder withEmbeddingDimension(Integer embeddingDimension) {
+                this.embeddingDimension = embeddingDimension;
+                return this;
+            }
+
+            public EmbeddingBuilder withModelPath(Path modelPath) {
+                this.modelPath = modelPath;
+                return this;
+            }
+
+            public EmbeddingBuilder withApiKey(String apiKey) {
+                this.apiKey = apiKey;
+                return this;
+            }
+
+            public EmbeddingBuilder withBatchSize(Integer batchSize) {
+                this.batchSize = batchSize;
+                return this;
+            }
+
+            public EmbeddingConfig build() {
+                return new EmbeddingConfig(this);
+            }
+        }
+    }
+
+    /**
+     * Index configuration section.
+     */
+    public static final class IndexConfig {
+        private final Path directory;
+
+        private IndexConfig(IndexBuilder builder) {
+            this.directory = builder.directory;
+        }
+
+        public static IndexBuilder builder() {
+            return new IndexBuilder();
+        }
+
+        public Path getDirectory() {
+            return directory;
+        }
+
+        public static final class IndexBuilder {
+            private Path directory;
+
+            private IndexBuilder() {
+            }
+
+            public IndexBuilder withDirectory(Path directory) {
+                this.directory = directory;
+                return this;
+            }
+
+            public IndexConfig build() {
+                Objects.requireNonNull(directory, "directory");
+                return new IndexConfig(this);
+            }
+        }
+    }
+
+    /**
+     * Search configuration section.
+     */
+    public static final class SearchConfig {
+        private final int topK;
+
+        private SearchConfig(SearchBuilder builder) {
+            this.topK = builder.topK != null ? Math.max(1, builder.topK) : 5;
+        }
+
+        public static SearchBuilder builder() {
+            return new SearchBuilder();
+        }
+
+        public int getTopK() {
+            return topK;
+        }
+
+        public static final class SearchBuilder {
+            private Integer topK;
+
+            private SearchBuilder() {
+            }
+
+            public SearchBuilder withTopK(Integer topK) {
+                this.topK = topK;
+                return this;
+            }
+
+            public SearchConfig build() {
+                return new SearchConfig(this);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ygmpkk/codesearch/config/ConfigLoader.java
+++ b/src/main/java/com/ygmpkk/codesearch/config/ConfigLoader.java
@@ -1,0 +1,191 @@
+package com.ygmpkk.codesearch.config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Loads the {@code config.yaml} configuration file for the application.
+ */
+public final class ConfigLoader {
+    private static final Logger logger = LogManager.getLogger(ConfigLoader.class);
+    private static final String CONFIG_FILE_NAME = "config.yaml";
+    private static final Yaml YAML = new Yaml();
+
+    private ConfigLoader() {
+    }
+
+    /**
+     * Load the configuration from the given home directory.
+     *
+     * @param homeDirectory the home directory containing {@code config.yaml}
+     * @return the loaded configuration, or defaults if no file is found
+     */
+    public static AppConfig load(Path homeDirectory) {
+        return load(homeDirectory, null);
+    }
+
+    /**
+     * Load the configuration using an optional explicit config path.
+     *
+     * @param homeDirectory the resolved home directory
+     * @param explicitConfigPath optional override for the config file location
+     * @return the loaded configuration
+     */
+    public static AppConfig load(Path homeDirectory, Path explicitConfigPath) {
+        Objects.requireNonNull(homeDirectory, "homeDirectory");
+        Path normalizedHome = homeDirectory.toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(normalizedHome);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create home directory: " + normalizedHome, e);
+        }
+
+        Path configPath = explicitConfigPath != null ? explicitConfigPath : normalizedHome.resolve(CONFIG_FILE_NAME);
+
+        if (Files.notExists(configPath)) {
+            logger.debug("Configuration file not found at {}. Writing default configuration.", configPath);
+            AppConfig defaults = AppConfig.createDefault(normalizedHome);
+            writeDefaultConfig(configPath, defaults);
+            return defaults;
+        }
+
+        try (InputStream input = Files.newInputStream(configPath)) {
+            Map<String, Object> root = YAML.load(input);
+            if (root == null) {
+                logger.warn("Configuration file {} is empty. Using defaults.", configPath);
+                return AppConfig.createDefault(normalizedHome);
+            }
+            return parseConfig(normalizedHome, root);
+        } catch (Exception e) {
+            logger.warn("Failed to read configuration from {}: {}. Using defaults.", configPath, e.getMessage());
+            logger.debug("Stack trace:", e);
+            return AppConfig.createDefault(normalizedHome);
+        }
+    }
+
+    private static AppConfig parseConfig(Path homeDirectory, Map<String, Object> root) {
+        AppConfig defaultConfig = AppConfig.createDefault(homeDirectory);
+
+        Map<String, Object> embeddingMap = asSection(root.get("embedding"));
+        String model = firstNonBlank(asString(embeddingMap.get("model")), defaultConfig.getEmbedding().getModel());
+        String modelName = firstNonBlank(asString(embeddingMap.get("modelName")), defaultConfig.getEmbedding().getModelName());
+        Integer embeddingDimension = asInteger(embeddingMap.get("embeddingDimension"));
+        Path modelPath = resolvePath(homeDirectory, asString(embeddingMap.get("modelPath")));
+        String apiKey = firstNonBlank(asString(embeddingMap.get("apiKey")), defaultConfig.getEmbedding().getApiKey());
+        Integer batchSize = asInteger(embeddingMap.get("batchSize"));
+
+        Map<String, Object> indexMap = asSection(root.get("index"));
+        Path indexDirectory = resolvePath(homeDirectory, asString(indexMap.get("directory")));
+        if (indexDirectory == null) {
+            indexDirectory = defaultConfig.getIndex().getDirectory();
+        }
+
+        Map<String, Object> searchMap = asSection(root.get("search"));
+        Integer topK = asInteger(searchMap.get("topK"));
+
+        return AppConfig.builder()
+                .withHomeDirectory(homeDirectory)
+                .withEmbedding(AppConfig.EmbeddingConfig.builder()
+                        .withModel(model)
+                        .withModelName(modelName)
+                        .withEmbeddingDimension(embeddingDimension)
+                        .withModelPath(modelPath)
+                        .withApiKey(apiKey)
+                        .withBatchSize(batchSize)
+                        .build())
+                .withIndex(AppConfig.IndexConfig.builder()
+                        .withDirectory(indexDirectory)
+                        .build())
+                .withSearch(AppConfig.SearchConfig.builder()
+                        .withTopK(topK)
+                        .build())
+                .build();
+    }
+
+    private static void writeDefaultConfig(Path configPath, AppConfig defaults) {
+        try {
+            Files.createDirectories(configPath.getParent());
+            Map<String, Object> configMap = new LinkedHashMap<>(defaults.toMap());
+            try (Writer writer = new OutputStreamWriter(Files.newOutputStream(configPath), StandardCharsets.UTF_8)) {
+                YAML.dump(configMap, writer);
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to write default configuration to {}: {}", configPath, e.getMessage());
+            logger.debug("Stack trace:", e);
+        }
+    }
+
+    private static Map<String, Object> asSection(Object section) {
+        if (section instanceof Map<?, ?> map) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() != null) {
+                    result.put(String.valueOf(entry.getKey()), entry.getValue());
+                }
+            }
+            return result;
+        }
+        return new LinkedHashMap<>();
+    }
+
+    private static String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String stringValue = String.valueOf(value).trim();
+        return stringValue.isEmpty() ? null : stringValue;
+    }
+
+    private static Integer asInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value).trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static String firstNonBlank(String primary, String fallback) {
+        return primary != null ? primary : fallback;
+    }
+
+    private static Path resolvePath(Path homeDirectory, String value) {
+        if (value == null) {
+            return null;
+        }
+        String expanded = value.startsWith("~")
+                ? value.replaceFirst("~", System.getProperty("user.home"))
+                : value;
+        Path path = Paths.get(expanded);
+        if (!path.isAbsolute()) {
+            path = homeDirectory.resolve(path);
+        }
+        return path.normalize();
+    }
+
+    /**
+     * Resolve the configuration path for a given home directory without loading it.
+     */
+    public static Path resolveConfigPath(Path homeDirectory) {
+        Objects.requireNonNull(homeDirectory, "homeDirectory");
+        return homeDirectory.toAbsolutePath().normalize().resolve(CONFIG_FILE_NAME);
+    }
+}

--- a/src/test/java/com/ygmpkk/codesearch/config/ConfigLoaderTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/config/ConfigLoaderTest.java
@@ -1,0 +1,64 @@
+package com.ygmpkk.codesearch.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadCreatesDefaultConfigurationWhenMissing() throws Exception {
+        Path homeDir = tempDir.resolve("home");
+
+        AppConfig config = ConfigLoader.load(homeDir);
+
+        assertNotNull(config);
+        assertEquals(homeDir.toAbsolutePath().normalize(), config.getHomeDirectory());
+        assertEquals("mock", config.getEmbedding().getModel());
+        assertEquals(32, config.getEmbedding().getBatchSize());
+        assertEquals(homeDir.resolve("index").toAbsolutePath().normalize(), config.getIndex().getDirectory());
+        assertEquals(5, config.getSearch().getTopK());
+
+        assertTrue(Files.exists(ConfigLoader.resolveConfigPath(homeDir)));
+    }
+
+    @Test
+    void loadReadsCustomConfiguration() throws Exception {
+        Path homeDir = tempDir.resolve("custom-home");
+        Path configPath = homeDir.resolve("config.yaml");
+        Files.createDirectories(homeDir);
+
+        String yaml = """
+                embedding:
+                  model: https://api.example.com/v1/embeddings
+                  modelName: remote-model
+                  embeddingDimension: 2048
+                  modelPath: ./models
+                  apiKey: secret-key
+                  batchSize: 10
+                index:
+                  directory: ./indexes/main
+                search:
+                  topK: 7
+                """;
+        Files.writeString(configPath, yaml);
+
+        AppConfig config = ConfigLoader.load(homeDir);
+
+        assertEquals("https://api.example.com/v1/embeddings", config.getEmbedding().getModel());
+        assertEquals("remote-model", config.getEmbedding().getModelName());
+        assertEquals(2048, config.getEmbedding().getEmbeddingDimension());
+        assertEquals(homeDir.resolve("models").toAbsolutePath().normalize(), config.getEmbedding().getModelPath());
+        assertEquals("secret-key", config.getEmbedding().getApiKey());
+        assertEquals(10, config.getEmbedding().getBatchSize());
+        assertEquals(homeDir.resolve("indexes/main").toAbsolutePath().normalize(), config.getIndex().getDirectory());
+        assertEquals(7, config.getSearch().getTopK());
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration loader and defaults driven by `config.yaml` under the CLI home directory
- refactor semi build/search commands to share embedding options and honour configuration, including real search execution
- document the new configuration flow and add tests covering config loading

## Testing
- ./gradlew test *(fails: dependency downloads blocked by 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e64888bb348324a905de12514a5f0a