### PR TITLE
feat: build semantic index with tree sitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,10 @@ dependencies {
     
     // ArcadeDB for multi-model database (graph + vector)
     implementation 'com.arcadedb:arcadedb-engine:24.6.1'
-    
+
+    // Tree-sitter bindings for Java-based parsing
+    implementation 'ch.usi.si.seart:java-tree-sitter:1.12.0'
+
     // DJL for deep learning model inference
     implementation platform('ai.djl:bom:0.34.0')
     implementation 'ai.djl:api'

--- a/src/main/java/com/ygmpkk/codesearch/SemiCommandSupport.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiCommandSupport.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
 public final class SemiCommandSupport {
     private static final Path DEFAULT_HOME = Paths.get(System.getProperty("user.home"), ".code-semi-graph");
     private static final String VECTOR_DB_DIRECTORY = "arcadedb-vector";
+    private static final String GRAPH_DB_DIRECTORY = "arcadedb-graph";
 
     private SemiCommandSupport() {
     }
@@ -77,6 +78,10 @@ public final class SemiCommandSupport {
 
     public static Path resolveVectorDatabasePath(Path indexDirectory) {
         return indexDirectory.resolve(VECTOR_DB_DIRECTORY);
+    }
+
+    public static Path resolveGraphDatabasePath(Path indexDirectory) {
+        return indexDirectory.resolve(GRAPH_DB_DIRECTORY);
     }
 
     private static String firstNonBlank(String value, String fallback) {

--- a/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
+++ b/src/main/java/com/ygmpkk/codesearch/SemiSearchCommand.java
@@ -161,12 +161,25 @@ public class SemiSearchCommand implements Callable<Integer> {
 
                 int rank = 1;
                 for (VectorDatabase.SearchResult result : results) {
+                    String location = result.getQualifiedClassName() != null && !result.getQualifiedClassName().isBlank()
+                            ? result.getQualifiedClassName()
+                            : result.getClassName();
+                    String method = result.getMethodSignature() != null && !result.getMethodSignature().isBlank()
+                            ? result.getMethodSignature()
+                            : result.getMethodName();
+
                     System.out.printf(
-                            "%d. %s (similarity: %.4f)%n",
+                            "%d. %s :: %s :: %s (tokens: %d, similarity: %.4f)%n",
                             rank++,
                             result.getFilePath(),
+                            location != null && !location.isBlank() ? location : "<unknown>",
+                            method != null && !method.isBlank() ? method : "<unknown>",
+                            result.getTokenCount(),
                             result.getSimilarity()
                     );
+                    if (!result.getProperties().isEmpty()) {
+                        System.out.printf("    Properties: %s%n", String.join(", ", result.getProperties()));
+                    }
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/ygmpkk/codesearch/analysis/CodeChunk.java
+++ b/src/main/java/com/ygmpkk/codesearch/analysis/CodeChunk.java
@@ -1,0 +1,93 @@
+package com.ygmpkk.codesearch.analysis;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a chunk of code extracted from a source file that will be indexed
+ * in the vector database. Each chunk carries the structural metadata required
+ * for semantic search and downstream tooling.
+ */
+public final class CodeChunk {
+    private final String chunkId;
+    private final Path filePath;
+    private final String packageName;
+    private final String className;
+    private final String qualifiedClassName;
+    private final List<String> properties;
+    private final String methodName;
+    private final String methodSignature;
+    private final String content;
+    private final int tokenCount;
+
+    public CodeChunk(
+            String chunkId,
+            Path filePath,
+            String packageName,
+            String className,
+            String qualifiedClassName,
+            List<String> properties,
+            String methodName,
+            String methodSignature,
+            String content,
+            int tokenCount
+    ) {
+        this.chunkId = Objects.requireNonNull(chunkId, "chunkId");
+        this.filePath = Objects.requireNonNull(filePath, "filePath");
+        this.packageName = packageName != null ? packageName : "";
+        this.className = className != null ? className : "";
+        this.qualifiedClassName = qualifiedClassName != null ? qualifiedClassName : this.className;
+        this.properties = properties != null ? List.copyOf(properties) : List.of();
+        this.methodName = methodName != null ? methodName : "";
+        this.methodSignature = methodSignature != null ? methodSignature : this.methodName;
+        this.content = Objects.requireNonNull(content, "content");
+        this.tokenCount = Math.max(0, tokenCount);
+    }
+
+    public String chunkId() {
+        return chunkId;
+    }
+
+    public Path filePath() {
+        return filePath;
+    }
+
+    public String fileName() {
+        return filePath.getFileName().toString();
+    }
+
+    public String packageName() {
+        return packageName;
+    }
+
+    public String className() {
+        return className;
+    }
+
+    public String qualifiedClassName() {
+        return qualifiedClassName;
+    }
+
+    public List<String> properties() {
+        return Collections.unmodifiableList(properties);
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public String methodSignature() {
+        return methodSignature;
+    }
+
+    public String content() {
+        return content;
+    }
+
+    public int tokenCount() {
+        return tokenCount;
+    }
+}
+

--- a/src/main/java/com/ygmpkk/codesearch/analysis/CodeFileAnalysis.java
+++ b/src/main/java/com/ygmpkk/codesearch/analysis/CodeFileAnalysis.java
@@ -1,0 +1,16 @@
+package com.ygmpkk.codesearch.analysis;
+
+import java.util.List;
+
+/**
+ * Aggregated result of analysing a single source file using tree-sitter. The
+ * analysis produces code chunks for vector indexing as well as graph nodes and
+ * edges describing structural relationships such as method invocations.
+ */
+public record CodeFileAnalysis(
+        List<CodeChunk> chunks,
+        List<GraphNode> nodes,
+        List<GraphEdge> edges
+) {
+}
+

--- a/src/main/java/com/ygmpkk/codesearch/analysis/GraphEdge.java
+++ b/src/main/java/com/ygmpkk/codesearch/analysis/GraphEdge.java
@@ -1,0 +1,10 @@
+package com.ygmpkk.codesearch.analysis;
+
+/**
+ * Lightweight representation of a relationship between two code nodes that is
+ * persisted to the graph database. Currently used for method invocation call
+ * chains.
+ */
+public record GraphEdge(String fromNodeId, String toNodeId, String relationshipType) {
+}
+

--- a/src/main/java/com/ygmpkk/codesearch/analysis/GraphNode.java
+++ b/src/main/java/com/ygmpkk/codesearch/analysis/GraphNode.java
@@ -1,0 +1,9 @@
+package com.ygmpkk.codesearch.analysis;
+
+/**
+ * Lightweight description of a code element (class, interface, method, etc.)
+ * that should be persisted to the graph database.
+ */
+public record GraphNode(String nodeId, String nodeType, String name, String filePath) {
+}
+

--- a/src/main/java/com/ygmpkk/codesearch/analysis/TreeSitterCodeAnalyzer.java
+++ b/src/main/java/com/ygmpkk/codesearch/analysis/TreeSitterCodeAnalyzer.java
@@ -1,0 +1,457 @@
+package com.ygmpkk.codesearch.analysis;
+
+import ch.usi.si.seart.treesitter.Language;
+import ch.usi.si.seart.treesitter.Languages;
+import ch.usi.si.seart.treesitter.Node;
+import ch.usi.si.seart.treesitter.Parser;
+import ch.usi.si.seart.treesitter.Tree;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Performs source code analysis using tree-sitter to produce structured chunks
+ * for vector indexing and call graph information for the graph database.
+ */
+public final class TreeSitterCodeAnalyzer {
+    private static final int MAX_TOKENS_PER_CHUNK = 32_768;
+    private static final String RELATION_CALLS = "calls";
+
+    private final Parser parser;
+    private final Map<String, Language> supportedLanguages;
+
+    public TreeSitterCodeAnalyzer() {
+        this.parser = new Parser();
+        this.supportedLanguages = Map.of(
+                "java", Languages.JAVA()
+        );
+    }
+
+    /**
+     * Analyse a file and produce code chunks and call graph relationships.
+     */
+    public CodeFileAnalysis analyse(Path file, String source) {
+        Objects.requireNonNull(file, "file");
+        Objects.requireNonNull(source, "source");
+
+        String extension = getExtension(file);
+        Language language = supportedLanguages.get(extension);
+        if (language == null) {
+            return fallbackAnalysis(file, source);
+        }
+
+        parser.setLanguage(language);
+
+        Tree tree = parser.parse(source.getBytes(StandardCharsets.UTF_8));
+        Node rootNode = tree.getRootNode();
+
+        String packageName = extractPackageName(rootNode, source);
+
+        Map<String, GraphNode> nodes = new HashMap<>();
+        Set<GraphEdge> edges = new LinkedHashSet<>();
+        List<CodeChunk> chunks = new ArrayList<>();
+
+        analyseRoot(rootNode, file, source, packageName, nodes, edges, chunks);
+
+        if (chunks.isEmpty()) {
+            // Fall back to chunking the entire file to ensure coverage.
+            return fallbackAnalysis(file, source);
+        }
+
+        return new CodeFileAnalysis(
+                List.copyOf(chunks),
+                new ArrayList<>(nodes.values()),
+                List.copyOf(edges)
+        );
+    }
+
+    private void analyseRoot(Node rootNode,
+                              Path file,
+                              String source,
+                              String packageName,
+                              Map<String, GraphNode> nodes,
+                              Set<GraphEdge> edges,
+                              List<CodeChunk> chunks) {
+        int namedChildCount = rootNode.getNamedChildCount();
+        for (int i = 0; i < namedChildCount; i++) {
+            Node child = rootNode.getNamedChild(i);
+            switch (child.getType()) {
+                case "class_declaration":
+                case "interface_declaration":
+                case "enum_declaration":
+                case "record_declaration":
+                    analyseTypeDeclaration(child, file, source, packageName, nodes, edges, chunks);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private void analyseTypeDeclaration(Node typeNode,
+                                        Path file,
+                                        String source,
+                                        String packageName,
+                                        Map<String, GraphNode> nodes,
+                                        Set<GraphEdge> edges,
+                                        List<CodeChunk> chunks) {
+        Node nameNode = typeNode.getChildByFieldName("name");
+        String className = nameNode != null ? slice(source, nameNode) : "";
+        String qualifiedClassName = buildQualifiedName(packageName, className);
+
+        String classNodeId = "class:" + qualifiedClassName;
+        nodes.putIfAbsent(classNodeId, new GraphNode(classNodeId, "class", qualifiedClassName, file.toString()));
+
+        Node bodyNode = findBodyNode(typeNode);
+        if (bodyNode == null) {
+            return;
+        }
+
+        List<String> properties = collectFieldNames(bodyNode, source);
+
+        int bodyChildren = bodyNode.getNamedChildCount();
+        for (int i = 0; i < bodyChildren; i++) {
+            Node member = bodyNode.getNamedChild(i);
+            switch (member.getType()) {
+                case "method_declaration":
+                case "constructor_declaration":
+                    analyseMethod(member, file, source, packageName, className, qualifiedClassName,
+                            properties, nodes, edges, chunks, classNodeId);
+                    break;
+                case "class_declaration":
+                case "interface_declaration":
+                case "enum_declaration":
+                case "record_declaration":
+                    analyseTypeDeclaration(member, file, source, packageName, nodes, edges, chunks);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private void analyseMethod(Node methodNode,
+                               Path file,
+                               String source,
+                               String packageName,
+                               String className,
+                               String qualifiedClassName,
+                               List<String> properties,
+                               Map<String, GraphNode> nodes,
+                               Set<GraphEdge> edges,
+                               List<CodeChunk> chunks,
+                               String classNodeId) {
+        Node nameNode = methodNode.getChildByFieldName("name");
+        if (nameNode == null) {
+            return;
+        }
+
+        Node parametersNode = methodNode.getChildByFieldName("parameters");
+        Node bodyNode = methodNode.getChildByFieldName("body");
+        if (bodyNode == null) {
+            return;
+        }
+
+        String methodName = slice(source, nameNode);
+        String parameterText = parametersNode != null ? slice(source, parametersNode) : "";
+        int parameterCount = estimateParameterCount(parameterText);
+        String methodId = "method:" + buildQualifiedName(packageName, className) + "#" + methodName + "/" + parameterCount;
+
+        nodes.putIfAbsent(methodId, new GraphNode(methodId, "method", methodName, file.toString()));
+        edges.add(new GraphEdge(classNodeId, methodId, "contains"));
+
+        String bodyText = slice(source, bodyNode);
+        List<String> chunkContents = chunkByTokenLimit(bodyText);
+
+        for (int i = 0; i < chunkContents.size(); i++) {
+            String chunkText = chunkContents.get(i);
+            int tokenCount = countTokens(chunkText);
+            String chunkId = methodId + ":" + (i + 1);
+            chunks.add(new CodeChunk(
+                    chunkId,
+                    file,
+                    packageName,
+                    className,
+                    qualifiedClassName,
+                    properties,
+                    methodName,
+                    methodName + parameterText,
+                    chunkText,
+                    tokenCount
+            ));
+        }
+
+        collectMethodCallEdges(bodyNode, source, methodId, nodes, edges);
+    }
+
+    private void collectMethodCallEdges(Node bodyNode,
+                                        String source,
+                                        String callerId,
+                                        Map<String, GraphNode> nodes,
+                                        Set<GraphEdge> edges) {
+        Deque<Node> stack = new ArrayDeque<>();
+        stack.push(bodyNode);
+
+        while (!stack.isEmpty()) {
+            Node current = stack.pop();
+            if ("method_invocation".equals(current.getType()) || "super_method_invocation".equals(current.getType())) {
+                Node calleeNode = current.getChildByFieldName("name");
+                if (calleeNode == null && "method_invocation".equals(current.getType())) {
+                    calleeNode = findIdentifierChild(current);
+                }
+                if (calleeNode != null) {
+                    String calleeName = slice(source, calleeNode);
+                    if (!calleeName.isBlank()) {
+                        String calleeId = "method:" + calleeName;
+                        nodes.putIfAbsent(calleeId, new GraphNode(calleeId, "method", calleeName, ""));
+                        edges.add(new GraphEdge(callerId, calleeId, RELATION_CALLS));
+                    }
+                }
+            }
+
+            int namedChildren = current.getNamedChildCount();
+            for (int i = 0; i < namedChildren; i++) {
+                stack.push(current.getNamedChild(i));
+            }
+        }
+    }
+
+    private Node findIdentifierChild(Node node) {
+        int namedChildren = node.getNamedChildCount();
+        for (int i = 0; i < namedChildren; i++) {
+            Node child = node.getNamedChild(i);
+            if ("identifier".equals(child.getType())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private Node findBodyNode(Node typeNode) {
+        int namedChildCount = typeNode.getNamedChildCount();
+        for (int i = 0; i < namedChildCount; i++) {
+            Node child = typeNode.getNamedChild(i);
+            String type = child.getType();
+            if (type.endsWith("_body") || "class_body".equals(type)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private List<String> collectFieldNames(Node bodyNode, String source) {
+        Set<String> names = new LinkedHashSet<>();
+        int childCount = bodyNode.getNamedChildCount();
+        for (int i = 0; i < childCount; i++) {
+            Node member = bodyNode.getNamedChild(i);
+            if (!"field_declaration".equals(member.getType())) {
+                continue;
+            }
+            int declarationChildren = member.getNamedChildCount();
+            for (int j = 0; j < declarationChildren; j++) {
+                Node declChild = member.getNamedChild(j);
+                if ("variable_declarator".equals(declChild.getType())) {
+                    Node identifierNode = declChild.getChildByFieldName("name");
+                    if (identifierNode == null) {
+                        identifierNode = findIdentifierChild(declChild);
+                    }
+                    if (identifierNode != null) {
+                        names.add(slice(source, identifierNode));
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(names);
+    }
+
+    private CodeFileAnalysis fallbackAnalysis(Path file, String source) {
+        List<String> chunks = chunkByTokenLimit(source);
+        List<CodeChunk> codeChunks = new ArrayList<>(chunks.size());
+        for (int i = 0; i < chunks.size(); i++) {
+            String content = chunks.get(i);
+            codeChunks.add(new CodeChunk(
+                    file.toString() + ":" + (i + 1),
+                    file,
+                    "",
+                    "",
+                    "",
+                    Collections.emptyList(),
+                    "",
+                    "",
+                    content,
+                    countTokens(content)
+            ));
+        }
+        return new CodeFileAnalysis(codeChunks, List.of(), List.of());
+    }
+
+    private int estimateParameterCount(String parameterText) {
+        if (parameterText == null || parameterText.isBlank()) {
+            return 0;
+        }
+        String trimmed = parameterText.trim();
+        if (trimmed.startsWith("(") && trimmed.endsWith(")")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1);
+        }
+        trimmed = trimmed.trim();
+        if (trimmed.isEmpty()) {
+            return 0;
+        }
+
+        int depth = 0;
+        int count = 1;
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            switch (c) {
+                case '<':
+                case '(':
+                case '[':
+                    depth++;
+                    break;
+                case '>':
+                case ')':
+                case ']':
+                    depth = Math.max(0, depth - 1);
+                    break;
+                case ',':
+                    if (depth == 0) {
+                        count++;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        return count;
+    }
+
+    private List<String> chunkByTokenLimit(String code) {
+        if (code.isBlank()) {
+            return List.of(code);
+        }
+
+        List<String> chunks = new ArrayList<>();
+        int length = code.length();
+        int chunkStart = 0;
+        int index = 0;
+        int tokenCount = 0;
+
+        while (index < length) {
+            char current = code.charAt(index);
+            if (!Character.isWhitespace(current)) {
+                int tokenEnd = index + 1;
+                if (Character.isLetterOrDigit(current) || current == '_') {
+                    while (tokenEnd < length) {
+                        char c = code.charAt(tokenEnd);
+                        if (Character.isLetterOrDigit(c) || c == '_') {
+                            tokenEnd++;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                tokenCount++;
+                index = tokenEnd;
+            } else {
+                index++;
+            }
+
+            if (tokenCount >= MAX_TOKENS_PER_CHUNK) {
+                chunks.add(code.substring(chunkStart, index));
+                chunkStart = index;
+                tokenCount = 0;
+            }
+        }
+
+        if (chunkStart < length) {
+            chunks.add(code.substring(chunkStart));
+        }
+
+        return chunks.isEmpty() ? List.of(code) : chunks;
+    }
+
+    private int countTokens(String code) {
+        if (code == null || code.isBlank()) {
+            return 0;
+        }
+        int tokens = 0;
+        int index = 0;
+        while (index < code.length()) {
+            char current = code.charAt(index);
+            if (!Character.isWhitespace(current)) {
+                tokens++;
+                if (Character.isLetterOrDigit(current) || current == '_') {
+                    while (++index < code.length()) {
+                        char c = code.charAt(index);
+                        if (!(Character.isLetterOrDigit(c) || c == '_')) {
+                            break;
+                        }
+                    }
+                } else {
+                    index++;
+                }
+            } else {
+                index++;
+            }
+        }
+        return tokens;
+    }
+
+    private String slice(String source, Node node) {
+        int start = Math.max(0, (int) node.getStartByte());
+        int end = Math.max(start, (int) node.getEndByte());
+        if (start >= source.length()) {
+            return "";
+        }
+        end = Math.min(source.length(), end);
+        return source.substring(start, end);
+    }
+
+    private String extractPackageName(Node rootNode, String source) {
+        int childCount = rootNode.getNamedChildCount();
+        for (int i = 0; i < childCount; i++) {
+            Node child = rootNode.getNamedChild(i);
+            if ("package_declaration".equals(child.getType())) {
+                Node nameNode = child.getChildByFieldName("name");
+                if (nameNode == null) {
+                    nameNode = findIdentifierChild(child);
+                }
+                if (nameNode != null) {
+                    return slice(source, nameNode).trim();
+                }
+            }
+        }
+        return "";
+    }
+
+    private String getExtension(Path file) {
+        String name = file.getFileName().toString();
+        int dotIndex = name.lastIndexOf('.');
+        if (dotIndex == -1) {
+            return "";
+        }
+        return name.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private String buildQualifiedName(String packageName, String simpleName) {
+        if (packageName == null || packageName.isBlank()) {
+            return simpleName != null ? simpleName : "";
+        }
+        if (simpleName == null || simpleName.isBlank()) {
+            return packageName;
+        }
+        return packageName + "." + simpleName;
+    }
+}
+

--- a/src/main/java/com/ygmpkk/codesearch/db/VectorDatabase.java
+++ b/src/main/java/com/ygmpkk/codesearch/db/VectorDatabase.java
@@ -1,5 +1,7 @@
 package com.ygmpkk.codesearch.db;
 
+import com.ygmpkk.codesearch.analysis.CodeChunk;
+
 import java.util.List;
 
 /**
@@ -18,7 +20,7 @@ public interface VectorDatabase extends AutoCloseable {
      * @param content Content of the code file
      * @param embedding Vector embedding of the code
      */
-    void storeEmbedding(String filePath, String content, float[] embedding) throws Exception;
+    void storeEmbedding(CodeChunk chunk, float[] embedding) throws Exception;
     
     /**
      * Search for similar code embeddings
@@ -38,24 +40,91 @@ public interface VectorDatabase extends AutoCloseable {
      * Result of a vector similarity search
      */
     class SearchResult {
+        private final String chunkId;
         private final String filePath;
+        private final String fileName;
+        private final String packageName;
+        private final String className;
+        private final String qualifiedClassName;
+        private final List<String> properties;
+        private final String methodName;
+        private final String methodSignature;
         private final String content;
+        private final int tokenCount;
         private final double similarity;
-        
-        public SearchResult(String filePath, String content, double similarity) {
+
+        public SearchResult(
+                String chunkId,
+                String filePath,
+                String fileName,
+                String packageName,
+                String className,
+                String qualifiedClassName,
+                List<String> properties,
+                String methodName,
+                String methodSignature,
+                String content,
+                int tokenCount,
+                double similarity
+        ) {
+            this.chunkId = chunkId;
             this.filePath = filePath;
+            this.fileName = fileName;
+            this.packageName = packageName;
+            this.className = className;
+            this.qualifiedClassName = qualifiedClassName;
+            this.properties = properties;
+            this.methodName = methodName;
+            this.methodSignature = methodSignature;
             this.content = content;
+            this.tokenCount = tokenCount;
             this.similarity = similarity;
         }
-        
+
+        public String getChunkId() {
+            return chunkId;
+        }
+
         public String getFilePath() {
             return filePath;
         }
-        
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public String getPackageName() {
+            return packageName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public String getQualifiedClassName() {
+            return qualifiedClassName;
+        }
+
+        public List<String> getProperties() {
+            return properties;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
+
+        public String getMethodSignature() {
+            return methodSignature;
+        }
+
         public String getContent() {
             return content;
         }
-        
+
+        public int getTokenCount() {
+            return tokenCount;
+        }
+
         public double getSimilarity() {
             return similarity;
         }


### PR DESCRIPTION
## Summary
- integrate a Tree-Sitter powered analysis pipeline to chunk source methods, persist method metadata, and write call graph relationships during `semi build`
- extend the vector database schema to store rich chunk metadata and expose it via CLI search results
- add the java-tree-sitter dependency alongside graph index path resolution so both the vector and graph indexes are managed together

## Testing
- `./gradlew test` *(fails: dependency downloads blocked by 403 responses for java-tree-sitter and snakeyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68e683058b908324b5b7ec4826dee436