### PR TITLE
feat: auto-detect tree-sitter languages from file names

### DIFF
--- a/src/main/java/com/ygmpkk/codesearch/parser/CodeChunker.java
+++ b/src/main/java/com/ygmpkk/codesearch/parser/CodeChunker.java
@@ -23,6 +23,7 @@ public class CodeChunker {
      */
     public record CodeChunk(
             String filePath,
+            String language,
             String packageName,
             String className,
             String methodName,
@@ -34,6 +35,9 @@ public class CodeChunker {
     ) {
         public String getFullContext() {
             StringBuilder context = new StringBuilder();
+            if (language != null && !language.isEmpty()) {
+                context.append("Language: ").append(language).append("\n");
+            }
             if (packageName != null && !packageName.isEmpty()) {
                 context.append("Package: ").append(packageName).append("\n");
             }
@@ -67,6 +71,7 @@ public class CodeChunker {
             String content = "// No methods found in file";
             CodeChunk chunk = new CodeChunk(
                     metadata.filePath(),
+                    metadata.language(),
                     metadata.packageName(),
                     metadata.className(),
                     "",
@@ -90,6 +95,7 @@ public class CodeChunker {
         for (CodeMetadata.MethodInfo method : metadata.methods()) {
             CodeChunk chunk = new CodeChunk(
                     metadata.filePath(),
+                    metadata.language(),
                     metadata.packageName(),
                     metadata.className(),
                     method.name(),
@@ -109,6 +115,7 @@ public class CodeChunker {
                 String truncatedBody = truncateToMaxChars(method.body(), MAX_CHUNK_CHARS);
                 chunk = new CodeChunk(
                         metadata.filePath(),
+                        metadata.language(),
                         metadata.packageName(),
                         metadata.className(),
                         method.name(),

--- a/src/main/java/com/ygmpkk/codesearch/parser/CodeMetadata.java
+++ b/src/main/java/com/ygmpkk/codesearch/parser/CodeMetadata.java
@@ -8,6 +8,7 @@ import java.util.List;
  */
 public record CodeMetadata(
         String filePath,
+        String language,
         String packageName,
         String className,
         List<String> properties,

--- a/src/test/java/com/ygmpkk/codesearch/parser/CodeChunkerTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/parser/CodeChunkerTest.java
@@ -33,6 +33,7 @@ class CodeChunkerTest {
 
         CodeMetadata metadata = new CodeMetadata(
                 "/test/File.java",
+                "java",
                 "com.test",
                 "TestClass",
                 List.of("field1", "field2"),
@@ -48,6 +49,7 @@ class CodeChunkerTest {
         // Verify first chunk
         CodeChunker.CodeChunk chunk1 = chunks.get(0);
         assertEquals("/test/File.java", chunk1.filePath());
+        assertEquals("java", chunk1.language());
         assertEquals("com.test", chunk1.packageName());
         assertEquals("TestClass", chunk1.className());
         assertEquals("testMethod", chunk1.methodName());
@@ -59,6 +61,7 @@ class CodeChunkerTest {
 
         // Verify context includes metadata
         String context1 = chunk1.getFullContext();
+        assertTrue(context1.contains("Language: java"));
         assertTrue(context1.contains("Package: com.test"));
         assertTrue(context1.contains("Class: TestClass"));
         assertTrue(context1.contains("Method: testMethod"));
@@ -69,6 +72,7 @@ class CodeChunkerTest {
     void testChunkingWithNoMethods() {
         CodeMetadata metadata = new CodeMetadata(
                 "/test/Empty.java",
+                "java",
                 "com.test",
                 "EmptyClass",
                 List.of(),
@@ -97,6 +101,7 @@ class CodeChunkerTest {
 
         CodeMetadata metadata = new CodeMetadata(
                 "/test/Large.java",
+                "java",
                 "com.test",
                 "LargeClass",
                 List.of(),

--- a/src/test/java/com/ygmpkk/codesearch/parser/TreeSitterParserTest.java
+++ b/src/test/java/com/ygmpkk/codesearch/parser/TreeSitterParserTest.java
@@ -34,6 +34,7 @@ class TreeSitterParserTest {
             CodeMetadata metadata = parser.parseJavaCode("/test/HelloWorld.java", javaCode);
 
             assertEquals("/test/HelloWorld.java", metadata.filePath());
+            assertEquals("java", metadata.language());
             assertEquals("com.example", metadata.packageName());
             assertEquals("HelloWorld", metadata.className());
             assertEquals(1, metadata.properties().size());
@@ -49,6 +50,24 @@ class TreeSitterParserTest {
             CodeMetadata.MethodInfo method2 = metadata.methods().get(1);
             assertEquals("getMessage", method2.name());
             assertEquals("String", method2.returnType());
+        }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "treesitter.available", matches = "true")
+    void testAutoDetectsLanguageFromFileName() throws Exception {
+        String pythonCode = """
+                def greet(name):
+                    print(f"Hello {name}")
+                """;
+
+        try (TreeSitterParser parser = new TreeSitterParser()) {
+            CodeMetadata metadata = parser.parseCode("/tmp/sample.py", pythonCode);
+
+            assertEquals("/tmp/sample.py", metadata.filePath());
+            assertEquals("python", metadata.language());
+            assertTrue(metadata.methods().isEmpty());
+            assertTrue(metadata.properties().isEmpty());
         }
     }
 


### PR DESCRIPTION
## Summary
- auto-detect tree-sitter languages from file names and cache parser instances per language
- propagate detected language into code metadata/chunking and fall back when structured data is unavailable
- exercise language detection in parser and chunker tests

## Testing
- ./gradlew test *(fails: Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e7977bdde88324926f79612a4c0531